### PR TITLE
Add macOS library names

### DIFF
--- a/mini_al.h
+++ b/mini_al.h
@@ -7432,7 +7432,7 @@ mal_result mal_context_init__openal(mal_context* pContext)
     libName = "libopenal.so";
 #endif
 #ifdef MAL_APPLE
-    // I don't own a Mac so a contribution here would be much appreciated! Just don't know what the library is called...
+    libName = "OpenAL.framework/OpenAL";
 #endif
 	if (libName == NULL) {
 		return MAL_NO_BACKEND;	// Don't know what the library name is called.
@@ -8314,7 +8314,8 @@ mal_result mal_context_init_backend_apis__nix(mal_context* pContext)
     // pthread
     const char* libpthreadFileNames[] = {
         "libpthread.so",
-        "libpthread.so.0"
+        "libpthread.so.0",
+        "libpthread.dylib"
     };
 
     for (size_t i = 0; i < sizeof(libpthreadFileNames) / sizeof(libpthreadFileNames[0]); ++i) {


### PR DESCRIPTION
macOS comes with system OpenAL framework, dlopen() can find it with just "OpenAL.framework/OpenAL" , it seems full path is not needed, but I only tested this in vmware, with Sierra 10.12, I don't have real hardware to test.