### PR TITLE
Support {Net,Open}BSD OSS

### DIFF
--- a/mini_al.h
+++ b/mini_al.h
@@ -8843,6 +8843,8 @@ mal_result mal_device_init__sdl(mal_context* pContext, mal_device_type type, mal
     mal_assert(pConfig != NULL);
     mal_assert(pDevice != NULL);
 
+    (void)pContext;
+
     // SDL wants the buffer size to be a power of 2. The SDL_AudioSpec property for this is only a Uint16, so we need
     // to explicitly clamp this because it will be easy to overflow.
     mal_uint32 bufferSize = pConfig->bufferSizeInFrames;

--- a/mini_al.h
+++ b/mini_al.h
@@ -59,7 +59,7 @@
 //
 // Building (BSD)
 // --------------
-// The BSD build uses OSS and should Just Work without any linking nor include path configuration.
+// BSD build uses OSS. Requires linking to -lossaudio on {Open,Net}BSD, but not FreeBSD.
 //
 // Building (Emscripten)
 // ---------------------
@@ -6711,6 +6711,10 @@ static mal_result mal_device__main_loop__alsa(mal_device* pDevice)
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/soundcard.h>
+
+#ifndef SNDCTL_DSP_HALT
+#define SNDCTL_DSP_HALT SNDCTL_DSP_RESET
+#endif
 
 int mal_open_temp_device__oss()
 {


### PR DESCRIPTION
Fixed this build failure building raylib:
http://www.cpantesters.org/cpan/report/a069fade-0e1f-11e8-a1cf-bb670eaac09d

Functionality is untested, but it now compiles on NetBSD. A quick google search for 
libossaudio OpenBSD indicates that linking to libossaudio would be required there too.

Raylib issue: @raysan5/raylib#463