### PR TITLE
Fix to Win32 desktop detection.

### DIFF
--- a/mini_al.h
+++ b/mini_al.h
@@ -255,7 +255,7 @@ extern "C" {
 // Platform/backend detection.
 #ifdef _WIN32
     #define MAL_WIN32
-    #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PC_APP || WINAPI_FAMILY_PHONE_APP)
+    #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
         #define MAL_WIN32_UWP
     #else
         #define MAL_WIN32_DESKTOP


### PR DESCRIPTION
This fixes (for me) detection for a plain Win32 program. For some reason, mini_al would default for me to  MAL_WIN32_UWP even though I am not using those APIs or set them. This would cause all sorts of problems when compiling.

I am using MSVC2017. Doing this change fixes that for me and should keep the functionality for UWP Metro apps.